### PR TITLE
Fix mass/masse typo in problem

### DIFF
--- a/phys-mod/source/notebooks/python-base/01-prise-en-main.ipynb
+++ b/phys-mod/source/notebooks/python-base/01-prise-en-main.ipynb
@@ -328,7 +328,7 @@
     "### Exercice : masse de la Terre\n",
     "\n",
     "1. Créer une variable `masse` avec la valeur `5.972e24`, qui représente la masse de la Terre en kg.\n",
-    "2. Afficher la valeur de cette variable à l'écran avec l'instruction `print(mass)`"
+    "2. Afficher la valeur de cette variable à l'écran avec l'instruction `print(masse)`"
    ]
   },
   {


### PR DESCRIPTION
L'énoncé de l'exercice invite à écrire ce code qui donne une erreur :
```
masse = 5.972e24
print(mass)
```